### PR TITLE
get_field_value: add override for JSONField

### DIFF
--- a/preserialize/utils.py
+++ b/preserialize/utils.py
@@ -137,7 +137,8 @@ def get_field_value(obj, name, allow_missing=False):
             try:
                 field = obj._meta.get_field(name)
 
-                if isinstance(field, Field):
+                if isinstance(field, Field) and field.__class__.__name__ \
+                        not in ('JSONField',):
                     value = field.get_prep_value(value)
             except FieldDoesNotExist:
                 pass


### PR DESCRIPTION
For some reason get_prep_value() on django.contrib.postgres.fields.jsonb.JSONField returns a psycopg2 object (serializing to a string), whereas the direct value is a Python object tree. The more intuitive approach is to return the JSON as an integrated part of the tree, instead of a string containing JSON.